### PR TITLE
feat: implement data generator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/gagansingh894/InferFlux
 
 go 1.22.8
 
-require github.com/stretchr/testify v1.10.0
+require (
+	github.com/stretchr/testify v1.10.0
+	gonum.org/v1/gonum v0.15.1
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa h1:FRnLl4eNAQl8hwxVVC17teOw8kdjVDVAiFMtgUdTSRQ=
+golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa/go.mod h1:zk2irFbV9DP96SEBUUAy67IdHUaZuSnrz1n472HUCLE=
+gonum.org/v1/gonum v0.15.1 h1:FNy7N6OUZVUaWG9pTiD+jlhdQ3lMP+/LcTpJ6+a8sQ0=
+gonum.org/v1/gonum v0.15.1/go.mod h1:eZTZuRFrzu5pcyjN5wJhcIhnUdNijYxX1T2IcrOGY0o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/pkg/agents/datagen.go
+++ b/pkg/agents/datagen.go
@@ -1,0 +1,45 @@
+package agents
+
+import (
+	"math/rand"
+
+	"github.com/gagansingh894/InferFlux/types"
+)
+
+type DataGen map[string]interface{}
+
+type Generator interface {
+	GenerateWithRandomSize(modelSpec types.ModelSpec) DataGen
+	GenerateWithFixedSize(modelSpec types.ModelSpec, size int) (DataGen, error)
+	GenerateWithinRange(modelSpec types.ModelSpec, lowerBound int, higherBound int) (DataGen, error)
+}
+
+func generateStringData(values []string, size int) []string {
+	out := make([]string, size)
+
+	for i := range out {
+		out[i] = values[rand.Intn(size)]
+	}
+
+	return out
+}
+
+func generateFloatData(mean float64, std float64, size int) []float64 {
+	out := make([]float64, size)
+
+	for i := range out {
+		out[i] = rand.NormFloat64()*std + mean
+	}
+
+	return out
+}
+
+func generateIntegerData(mean float64, std float64, size int) []int64 {
+	out := make([]int64, size)
+
+	for i := range out {
+		out[i] = int64(rand.NormFloat64()*std + mean)
+	}
+
+	return out
+}

--- a/pkg/agents/grpc.go
+++ b/pkg/agents/grpc.go
@@ -1,7 +1,102 @@
 package agents
 
+import (
+	"errors"
+	"math/rand"
+
+	"github.com/gagansingh894/InferFlux/types"
+)
+
 type GRPCAgent struct{}
 
 func NewGRPCAgent() (*GRPCAgent, error) {
 	return &GRPCAgent{}, nil
+}
+
+func (a *GRPCAgent) GenerateWithRandomSize(modelSpec types.ModelSpec) DataGen {
+	out := make(DataGen)
+	size := rand.Intn(1500) + 1
+
+	for key, value := range modelSpec {
+		switch value.Dtype {
+		case types.String:
+			out[key] = generateStringData(value.Constraint.StringConstraint.Values, size)
+		case types.Int:
+			out[key] = generateIntegerData(
+				value.Constraint.NumericConstraint.Mean,
+				value.Constraint.NumericConstraint.StandardDeviation,
+				size,
+			)
+		case types.Float:
+			out[key] = generateFloatData(
+				value.Constraint.NumericConstraint.Mean,
+				value.Constraint.NumericConstraint.StandardDeviation,
+				size,
+			)
+		}
+	}
+
+	return out
+}
+
+func (a *GRPCAgent) GenerateWithFixedSize(modelSpec types.ModelSpec, size int) (DataGen, error) {
+	out := make(DataGen)
+
+	if size <= 0 {
+		return nil, errors.New("size must be greater than zero")
+	}
+
+	for key, value := range modelSpec {
+		switch value.Dtype {
+		case types.String:
+			out[key] = generateStringData(value.Constraint.StringConstraint.Values, size)
+		case types.Int:
+			out[key] = generateIntegerData(
+				value.Constraint.NumericConstraint.Mean,
+				value.Constraint.NumericConstraint.StandardDeviation,
+				size,
+			)
+		case types.Float:
+			out[key] = generateFloatData(
+				value.Constraint.NumericConstraint.Mean,
+				value.Constraint.NumericConstraint.StandardDeviation,
+				size,
+			)
+		}
+	}
+
+	return out, nil
+}
+
+func (a *GRPCAgent) GenerateWithinRange(modelSpec types.ModelSpec, lowerBound int, upperBound int) (DataGen, error) {
+	out := make(DataGen)
+
+	if lowerBound <= 0 {
+		return nil, errors.New("lower bound must be greater than zero")
+	}
+
+	if upperBound <= lowerBound {
+		return nil, errors.New("higher bound must be greater than lower")
+	}
+
+	for key, value := range modelSpec {
+		switch value.Dtype {
+		case types.String:
+			out[key] = generateStringData(value.Constraint.StringConstraint.Values, upperBound)[lowerBound:upperBound]
+		case types.Int:
+			out[key] = generateIntegerData(
+				value.Constraint.NumericConstraint.Mean,
+				value.Constraint.NumericConstraint.StandardDeviation,
+				upperBound,
+			)[lowerBound:upperBound]
+		case types.Float:
+			out[key] = generateFloatData(
+				value.Constraint.NumericConstraint.Mean,
+				value.Constraint.NumericConstraint.StandardDeviation,
+				upperBound,
+			)[lowerBound:upperBound]
+		}
+	}
+
+	return out, nil
 }

--- a/pkg/agents/grpc.go
+++ b/pkg/agents/grpc.go
@@ -2,6 +2,7 @@ package agents
 
 import (
 	"errors"
+	"github.com/gagansingh894/InferFlux/pkg/generator"
 	"math/rand"
 
 	"github.com/gagansingh894/InferFlux/types"
@@ -13,22 +14,22 @@ func NewGRPCAgent() (*GRPCAgent, error) {
 	return &GRPCAgent{}, nil
 }
 
-func (a *GRPCAgent) GenerateWithRandomSize(modelSpec types.ModelSpec) DataGen {
-	out := make(DataGen)
+func (a *GRPCAgent) GenerateWithRandomSize(modelSpec types.ModelSpec) generator.DataGen {
+	out := make(generator.DataGen)
 	size := rand.Intn(1500) + 1
 
 	for key, value := range modelSpec {
 		switch value.Dtype {
 		case types.String:
-			out[key] = generateStringData(value.Constraint.StringConstraint.Values, size)
+			out[key] = generator.GenerateStringData(value.Constraint.StringConstraint.Values, size)
 		case types.Int:
-			out[key] = generateIntegerData(
+			out[key] = generator.GenerateIntegerData(
 				value.Constraint.NumericConstraint.Mean,
 				value.Constraint.NumericConstraint.StandardDeviation,
 				size,
 			)
 		case types.Float:
-			out[key] = generateFloatData(
+			out[key] = generator.GenerateFloatData(
 				value.Constraint.NumericConstraint.Mean,
 				value.Constraint.NumericConstraint.StandardDeviation,
 				size,
@@ -39,8 +40,8 @@ func (a *GRPCAgent) GenerateWithRandomSize(modelSpec types.ModelSpec) DataGen {
 	return out
 }
 
-func (a *GRPCAgent) GenerateWithFixedSize(modelSpec types.ModelSpec, size int) (DataGen, error) {
-	out := make(DataGen)
+func (a *GRPCAgent) GenerateWithFixedSize(modelSpec types.ModelSpec, size int) (generator.DataGen, error) {
+	out := make(generator.DataGen)
 
 	if size <= 0 {
 		return nil, errors.New("size must be greater than zero")
@@ -49,15 +50,15 @@ func (a *GRPCAgent) GenerateWithFixedSize(modelSpec types.ModelSpec, size int) (
 	for key, value := range modelSpec {
 		switch value.Dtype {
 		case types.String:
-			out[key] = generateStringData(value.Constraint.StringConstraint.Values, size)
+			out[key] = generator.GenerateStringData(value.Constraint.StringConstraint.Values, size)
 		case types.Int:
-			out[key] = generateIntegerData(
+			out[key] = generator.GenerateIntegerData(
 				value.Constraint.NumericConstraint.Mean,
 				value.Constraint.NumericConstraint.StandardDeviation,
 				size,
 			)
 		case types.Float:
-			out[key] = generateFloatData(
+			out[key] = generator.GenerateFloatData(
 				value.Constraint.NumericConstraint.Mean,
 				value.Constraint.NumericConstraint.StandardDeviation,
 				size,
@@ -68,8 +69,8 @@ func (a *GRPCAgent) GenerateWithFixedSize(modelSpec types.ModelSpec, size int) (
 	return out, nil
 }
 
-func (a *GRPCAgent) GenerateWithinRange(modelSpec types.ModelSpec, lowerBound int, upperBound int) (DataGen, error) {
-	out := make(DataGen)
+func (a *GRPCAgent) GenerateWithinRange(modelSpec types.ModelSpec, lowerBound int, upperBound int) (generator.DataGen, error) {
+	out := make(generator.DataGen)
 
 	if lowerBound <= 0 {
 		return nil, errors.New("lower bound must be greater than zero")
@@ -82,15 +83,15 @@ func (a *GRPCAgent) GenerateWithinRange(modelSpec types.ModelSpec, lowerBound in
 	for key, value := range modelSpec {
 		switch value.Dtype {
 		case types.String:
-			out[key] = generateStringData(value.Constraint.StringConstraint.Values, upperBound)[lowerBound:upperBound]
+			out[key] = generator.GenerateStringData(value.Constraint.StringConstraint.Values, upperBound)[lowerBound:upperBound]
 		case types.Int:
-			out[key] = generateIntegerData(
+			out[key] = generator.GenerateIntegerData(
 				value.Constraint.NumericConstraint.Mean,
 				value.Constraint.NumericConstraint.StandardDeviation,
 				upperBound,
 			)[lowerBound:upperBound]
 		case types.Float:
-			out[key] = generateFloatData(
+			out[key] = generator.GenerateFloatData(
 				value.Constraint.NumericConstraint.Mean,
 				value.Constraint.NumericConstraint.StandardDeviation,
 				upperBound,

--- a/pkg/agents/grpc.go
+++ b/pkg/agents/grpc.go
@@ -2,9 +2,9 @@ package agents
 
 import (
 	"errors"
-	"github.com/gagansingh894/InferFlux/pkg/generator"
 	"math/rand"
 
+	"github.com/gagansingh894/InferFlux/pkg/generator"
 	"github.com/gagansingh894/InferFlux/types"
 )
 

--- a/pkg/agents/http.go
+++ b/pkg/agents/http.go
@@ -1,7 +1,102 @@
 package agents
 
+import (
+	"errors"
+	"math/rand"
+
+	"github.com/gagansingh894/InferFlux/types"
+)
+
 type HTTPAgent struct{}
 
 func NewHTTPAgent() (*HTTPAgent, error) {
 	return &HTTPAgent{}, nil
+}
+
+func (a *HTTPAgent) GenerateWithRandomSize(modelSpec types.ModelSpec) DataGen {
+	out := make(DataGen)
+	size := rand.Intn(1500) + 1
+
+	for key, value := range modelSpec {
+		switch value.Dtype {
+		case types.String:
+			out[key] = generateStringData(value.Constraint.StringConstraint.Values, size)
+		case types.Int:
+			out[key] = generateIntegerData(
+				value.Constraint.NumericConstraint.Mean,
+				value.Constraint.NumericConstraint.StandardDeviation,
+				size,
+			)
+		case types.Float:
+			out[key] = generateFloatData(
+				value.Constraint.NumericConstraint.Mean,
+				value.Constraint.NumericConstraint.StandardDeviation,
+				size,
+			)
+		}
+	}
+
+	return out
+}
+
+func (a *HTTPAgent) GenerateWithFixedSize(modelSpec types.ModelSpec, size int) (DataGen, error) {
+	out := make(DataGen)
+
+	if size <= 0 {
+		return nil, errors.New("size must be greater than zero")
+	}
+
+	for key, value := range modelSpec {
+		switch value.Dtype {
+		case types.String:
+			out[key] = generateStringData(value.Constraint.StringConstraint.Values, size)
+		case types.Int:
+			out[key] = generateIntegerData(
+				value.Constraint.NumericConstraint.Mean,
+				value.Constraint.NumericConstraint.StandardDeviation,
+				size,
+			)
+		case types.Float:
+			out[key] = generateFloatData(
+				value.Constraint.NumericConstraint.Mean,
+				value.Constraint.NumericConstraint.StandardDeviation,
+				size,
+			)
+		}
+	}
+
+	return out, nil
+}
+
+func (a *HTTPAgent) GenerateWithinRange(modelSpec types.ModelSpec, lowerBound int, upperBound int) (DataGen, error) {
+	out := make(DataGen)
+
+	if lowerBound <= 0 {
+		return nil, errors.New("lower bound must be greater than zero")
+	}
+
+	if upperBound <= lowerBound {
+		return nil, errors.New("higher bound must be greater than lower")
+	}
+
+	for key, value := range modelSpec {
+		switch value.Dtype {
+		case types.String:
+			out[key] = generateStringData(value.Constraint.StringConstraint.Values, upperBound)[lowerBound:upperBound]
+		case types.Int:
+			out[key] = generateIntegerData(
+				value.Constraint.NumericConstraint.Mean,
+				value.Constraint.NumericConstraint.StandardDeviation,
+				upperBound,
+			)[lowerBound:upperBound]
+		case types.Float:
+			out[key] = generateFloatData(
+				value.Constraint.NumericConstraint.Mean,
+				value.Constraint.NumericConstraint.StandardDeviation,
+				upperBound,
+			)[lowerBound:upperBound]
+		}
+	}
+
+	return out, nil
 }

--- a/pkg/agents/http.go
+++ b/pkg/agents/http.go
@@ -2,6 +2,7 @@ package agents
 
 import (
 	"errors"
+	"github.com/gagansingh894/InferFlux/pkg/generator"
 	"math/rand"
 
 	"github.com/gagansingh894/InferFlux/types"
@@ -13,22 +14,22 @@ func NewHTTPAgent() (*HTTPAgent, error) {
 	return &HTTPAgent{}, nil
 }
 
-func (a *HTTPAgent) GenerateWithRandomSize(modelSpec types.ModelSpec) DataGen {
-	out := make(DataGen)
+func (a *HTTPAgent) GenerateWithRandomSize(modelSpec types.ModelSpec) generator.DataGen {
+	out := make(generator.DataGen)
 	size := rand.Intn(1500) + 1
 
 	for key, value := range modelSpec {
 		switch value.Dtype {
 		case types.String:
-			out[key] = generateStringData(value.Constraint.StringConstraint.Values, size)
+			out[key] = generator.GenerateStringData(value.Constraint.StringConstraint.Values, size)
 		case types.Int:
-			out[key] = generateIntegerData(
+			out[key] = generator.GenerateIntegerData(
 				value.Constraint.NumericConstraint.Mean,
 				value.Constraint.NumericConstraint.StandardDeviation,
 				size,
 			)
 		case types.Float:
-			out[key] = generateFloatData(
+			out[key] = generator.GenerateFloatData(
 				value.Constraint.NumericConstraint.Mean,
 				value.Constraint.NumericConstraint.StandardDeviation,
 				size,
@@ -39,8 +40,8 @@ func (a *HTTPAgent) GenerateWithRandomSize(modelSpec types.ModelSpec) DataGen {
 	return out
 }
 
-func (a *HTTPAgent) GenerateWithFixedSize(modelSpec types.ModelSpec, size int) (DataGen, error) {
-	out := make(DataGen)
+func (a *HTTPAgent) GenerateWithFixedSize(modelSpec types.ModelSpec, size int) (generator.DataGen, error) {
+	out := make(generator.DataGen)
 
 	if size <= 0 {
 		return nil, errors.New("size must be greater than zero")
@@ -49,15 +50,15 @@ func (a *HTTPAgent) GenerateWithFixedSize(modelSpec types.ModelSpec, size int) (
 	for key, value := range modelSpec {
 		switch value.Dtype {
 		case types.String:
-			out[key] = generateStringData(value.Constraint.StringConstraint.Values, size)
+			out[key] = generator.GenerateStringData(value.Constraint.StringConstraint.Values, size)
 		case types.Int:
-			out[key] = generateIntegerData(
+			out[key] = generator.GenerateIntegerData(
 				value.Constraint.NumericConstraint.Mean,
 				value.Constraint.NumericConstraint.StandardDeviation,
 				size,
 			)
 		case types.Float:
-			out[key] = generateFloatData(
+			out[key] = generator.GenerateFloatData(
 				value.Constraint.NumericConstraint.Mean,
 				value.Constraint.NumericConstraint.StandardDeviation,
 				size,
@@ -68,8 +69,8 @@ func (a *HTTPAgent) GenerateWithFixedSize(modelSpec types.ModelSpec, size int) (
 	return out, nil
 }
 
-func (a *HTTPAgent) GenerateWithinRange(modelSpec types.ModelSpec, lowerBound int, upperBound int) (DataGen, error) {
-	out := make(DataGen)
+func (a *HTTPAgent) GenerateWithinRange(modelSpec types.ModelSpec, lowerBound int, upperBound int) (generator.DataGen, error) {
+	out := make(generator.DataGen)
 
 	if lowerBound <= 0 {
 		return nil, errors.New("lower bound must be greater than zero")
@@ -82,15 +83,15 @@ func (a *HTTPAgent) GenerateWithinRange(modelSpec types.ModelSpec, lowerBound in
 	for key, value := range modelSpec {
 		switch value.Dtype {
 		case types.String:
-			out[key] = generateStringData(value.Constraint.StringConstraint.Values, upperBound)[lowerBound:upperBound]
+			out[key] = generator.GenerateStringData(value.Constraint.StringConstraint.Values, upperBound)[lowerBound:upperBound]
 		case types.Int:
-			out[key] = generateIntegerData(
+			out[key] = generator.GenerateIntegerData(
 				value.Constraint.NumericConstraint.Mean,
 				value.Constraint.NumericConstraint.StandardDeviation,
 				upperBound,
 			)[lowerBound:upperBound]
 		case types.Float:
-			out[key] = generateFloatData(
+			out[key] = generator.GenerateFloatData(
 				value.Constraint.NumericConstraint.Mean,
 				value.Constraint.NumericConstraint.StandardDeviation,
 				upperBound,

--- a/pkg/agents/http.go
+++ b/pkg/agents/http.go
@@ -2,9 +2,9 @@ package agents
 
 import (
 	"errors"
-	"github.com/gagansingh894/InferFlux/pkg/generator"
 	"math/rand"
 
+	"github.com/gagansingh894/InferFlux/pkg/generator"
 	"github.com/gagansingh894/InferFlux/types"
 )
 

--- a/pkg/engine.go
+++ b/pkg/engine.go
@@ -1,7 +1,0 @@
-package pkg
-
-import "context"
-
-type LoadTester interface {
-	Start(ctx context.Context) error
-}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1,0 +1,7 @@
+package engine
+
+import "context"
+
+type WorkloadEvaluator interface {
+	StressAndBenchmark(ctx context.Context) error
+}

--- a/pkg/generator/datagen.go
+++ b/pkg/generator/datagen.go
@@ -1,4 +1,4 @@
-package agents
+package generator
 
 import (
 	"math/rand"
@@ -14,7 +14,7 @@ type Generator interface {
 	GenerateWithinRange(modelSpec types.ModelSpec, lowerBound int, higherBound int) (DataGen, error)
 }
 
-func generateStringData(values []string, size int) []string {
+func GenerateStringData(values []string, size int) []string {
 	out := make([]string, size)
 
 	for i := range out {
@@ -24,7 +24,7 @@ func generateStringData(values []string, size int) []string {
 	return out
 }
 
-func generateFloatData(mean float64, std float64, size int) []float64 {
+func GenerateFloatData(mean float64, std float64, size int) []float64 {
 	out := make([]float64, size)
 
 	for i := range out {
@@ -34,7 +34,7 @@ func generateFloatData(mean float64, std float64, size int) []float64 {
 	return out
 }
 
-func generateIntegerData(mean float64, std float64, size int) []int64 {
+func GenerateIntegerData(mean float64, std float64, size int) []int64 {
 	out := make([]int64, size)
 
 	for i := range out {

--- a/pkg/generator/datagen.go
+++ b/pkg/generator/datagen.go
@@ -18,7 +18,7 @@ func GenerateStringData(values []string, size int) []string {
 	out := make([]string, size)
 
 	for i := range out {
-		out[i] = values[rand.Intn(size)]
+		out[i] = values[rand.Intn(len(values))]
 	}
 
 	return out

--- a/pkg/generator/datagen_test.go
+++ b/pkg/generator/datagen_test.go
@@ -1,0 +1,63 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gonum.org/v1/gonum/stat"
+)
+
+func TestGenerateFloatData(t *testing.T) {
+	// Arrange
+	mean := 50.0
+	std := 10.0
+	size := 1000
+
+	// Act
+	data := GenerateFloatData(mean, std, size)
+
+	// Assert
+	calculatedMean := stat.Mean(data, nil)
+	calculatedStddev := stat.StdDev(data, nil)
+	assert.InDelta(t, mean, calculatedMean, 0.5)
+	assert.InDelta(t, std, calculatedStddev, 0.5)
+	assert.Len(t, data, size)
+
+}
+
+func TestGenerateIntegerData(t *testing.T) {
+	// Arrange
+	mean := 50.0
+	std := 10.0
+	size := 1000
+
+	// Act
+	data := GenerateIntegerData(mean, std, size)
+
+	// Assert
+	assert.InDelta(t, mean, calculateAverage(data, size), 0.5)
+	assert.Len(t, data, size)
+}
+
+func TestGenerateStringData(t *testing.T) {
+	// Arrange
+	values := []string{"a", "b", "c"}
+	size := 1000
+
+	// Act
+	data := GenerateStringData(values, size)
+
+	// Assert
+	assert.Len(t, data, size)
+
+}
+
+func calculateAverage(data []int64, size int) float64 {
+	var sum int64
+
+	for _, v := range data {
+		sum += v
+	}
+
+	return float64(sum) / float64(size)
+}


### PR DESCRIPTION
This PR implements the data generator based on the model spec file. `Generator` provides 3 methods for generating the data based on `Constraints`.

- `GenerateWithRandomSize`
- `GenerateWithFixedSize`
- `GenerateWithinRange`

The above methods are implemented for `HTTPAgent` and `GRPCAgent`.